### PR TITLE
errinjct: Remove platform check to enable KVM guests

### DIFF
--- a/src/errinjct/errinjct.c
+++ b/src/errinjct/errinjct.c
@@ -691,12 +691,6 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	if (get_platform() != PLATFORM_PSERIES_LPAR) {
-		fprintf(stderr, "%s: is not supported on the %s platform\n",
-							argv[0], platform_name);
-		exit(1);
-	}
-
 	/* Make sure the error injection facility is available */
 	fd = open(EI_IBM_ERRINJCT, O_RDONLY);
 	if (fd == -1) {


### PR DESCRIPTION
qemu/KVM guests can have RTAS as well.  There's already a check to see if RTAS is present, there's no need to hardcode the supported platform.  Removing this check allows errinjct to work on KVM guests.

Signed-off-by: Russell Currey ruscur@russell.cc
