### PR TITLE
findtools must be called before is_driver_installed

### DIFF
--- a/scripts/hvcsadmin
+++ b/scripts/hvcsadmin
@@ -707,6 +707,14 @@ GetOptions (
 
     verboseprint("$app_name: executing in verbose mode.\n");
 
+    #--------------- Look for the systool application -----------------------
+    # The systool application is required for invoking most/many of these
+    # operations so we'll express it as a standard requirement.
+    if (findsystools()) {
+        exit;
+    }
+
+
     # DON'T rely on the module existence to determine whether $driver is
     # supported since it could have been built into the kernel.
 
@@ -715,12 +723,6 @@ GetOptions (
         exit;
     }
 
-    #--------------- Look for the systool application -----------------------
-    # The systool application is required for invoking most/many of these
-    # operations so we'll express it as a standard requirement.
-    if (findsystools()) {
-        exit;
-    }
 
     if ($status) {
         status();


### PR DESCRIPTION
Hi, 

is_driver_installed is using systools, where as the same is checked for existence in findtools which is called later. It has to be called before to get the proper error message. 

The patch will first check for systools before checking for drivers.

It will avoid the following situation.

hvcsadmin -status
Can't exec "systool": No such file or directory at /usr/sbin/hvcsadmin line 272.
systool:  No such file or directory at /usr/sbin/hvcsadmin line 272.

Regards
Hariharan T.S
