### PR TITLE
[RFC] ofpathname should not loop indefinitely in get_slave

### DIFF
--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -409,7 +409,9 @@ print_aliases()
 get_slave()
 {
 	cd /sys/class/*/$1
-	while [[ -n "`ls slaves 2> /dev/null`" ]]; do cd slaves/*; done
+	while [[ -n "`ls slaves 2> /dev/null`" ]]; do
+	    cd `echo slaves/* |head -n1 |cut -d " " -f1`;
+	done
 	$FIND /dev -name "`basename $PWD`"
 }
 


### PR DESCRIPTION
This is a bypass for a problem raised on openSUSE with bug
https://bugzilla.suse.com/show_bug.cgi?id=1011529

RFC as not sure this is the best way to solve it.

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>