### PR TITLE
drmgr: load rpadlpar_io on -C as well

### DIFF
--- a/src/drmgr/common.c
+++ b/src/drmgr/common.c
@@ -114,13 +114,13 @@ static int check_kmods(void)
 
 	/* We only need to do this for PHB/SLOT/PCI operations */
 	if (usr_drc_type != DRC_TYPE_PCI && usr_drc_type != DRC_TYPE_PHB &&
-	    usr_drc_type != DRC_TYPE_SLOT)
+	    usr_drc_type != DRC_TYPE_SLOT && !display_capabilities)
 		return 0;
 
 	/* We don't use rpadlar_io/rpaphp for PCI operations run with the
 	 * -v / virtio flag, which relies on generic PCI rescan instead
 	 */
-	if (usr_drc_type == DRC_TYPE_PCI && pci_virtio)
+	if (usr_drc_type == DRC_TYPE_PCI && pci_virtio && !display_capabilities)
 		return 0;
 
 	/* Before checking for dlpar capability, we need to ensure that

--- a/src/drmgr/dr.h
+++ b/src/drmgr/dr.h
@@ -68,6 +68,7 @@ enum drc_type {DRC_TYPE_NONE, DRC_TYPE_PCI, DRC_TYPE_SLOT, DRC_TYPE_PHB,
 	       DRC_TYPE_HIBERNATE, DRC_TYPE_MIGRATION};
 
 extern enum drmgr_action usr_action;
+extern int display_capabilities;
 extern int usr_slot_identification;
 extern int usr_timeout;
 extern char *usr_drc_name;

--- a/src/drmgr/drmgr.c
+++ b/src/drmgr/drmgr.c
@@ -38,7 +38,6 @@ int output_level = 1; /* default to lowest output level */
 int log_fd = 0;
 int action_cnt = 0;
 
-static int display_capabilities = 0;
 static int handle_prrn_event = 0;
 static int display_usage = 0;
 

--- a/src/drmgr/options.c
+++ b/src/drmgr/options.c
@@ -21,6 +21,9 @@
 /* Global User Specifications */
 enum drmgr_action usr_action = NONE;
 
+/* the init routines may need to know this to enable all features */
+int display_capabilities = 0;
+
 /* default is to do slot identification, unless the drmgr -I
  * option is specified.
  */


### PR DESCRIPTION
Users do drmgr -C to verify their system.

However, -C does not select any hotplug type, and the rpadlpar_io kernel
module is loaded only when hotplug type pci, phb or slot is selected.

So check display_capabilities as well as the usr_drc_type

Signed-off-by: Michal Suchanek <msuchanek@suse.de>