### PR TITLE
Set udevadm path to /bin

### DIFF
--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -349,7 +349,7 @@ is_pata_dev()
     local sysfs_dir
     local udev_path
     local udevinfo="/usr/bin/udevinfo"
-    local udevadm="/sbin/udevadm"
+    local udevadm="/bin/udevadm"
 
     if [[ -a $udevadm ]]; then
         udev_path=`$udevadm info --query=path --name=$DEVNAME`


### PR DESCRIPTION
At least in Debian/Ubuntu udevadm is located in /bin
for several years, and it is intended to drop the
compatibility-symlink in /sbin.

Debian-Bug: https://bugs.debian.org/852575