### PR TITLE
update_flash_nv: fixup null byte command substitution warning

### DIFF
--- a/scripts/update_flash_nv
+++ b/scripts/update_flash_nv
@@ -313,7 +313,7 @@ fsp_validate_flash() {
 	echo 1 > $SYS_VALIDATE_FLASH 2>/dev/null
 
 	# Display appropriate message, exiting if necessary
-	output="$(cat $SYS_VALIDATE_FLASH)"
+	output="$(tr -d '\0' < $SYS_VALIDATE_FLASH)"
 	fsp_echo_validate_return_status "$output"
 }
 

--- a/src/drmgr/drmgr.c
+++ b/src/drmgr/drmgr.c
@@ -310,12 +310,16 @@ struct command *get_command(void)
  		usr_action = HIBERNATE;
  		return &commands[DRSLOT_CHRP_PHIB];
 		break;
+	case DRC_TYPE_MIGRATION:
+		usr_action = MIGRATE;
+		return &commands[DRMIG_CHRP_PMIG];
+		break;
 	default:
 		/* If we make it this far, the user specified an invalid
 		 * connector type.
 		 */
 		say(ERROR, "Dynamic reconfiguration is not supported for "
-		    "connector\ntype \"%s\" on this system\n", usr_drc_type);
+		    "connector\ntype \"%d\" on this system\n", usr_drc_type);
 		break;
 	}
 


### PR DESCRIPTION
the command execution of update_flash_nv returns following output.
/usr/sbin/update_flash_nv: line 316: warning: command substitution: ignored null byte in input 

The proposed patch should fix the issue.