### PR TITLE
Add support for OF pathnames on Power Mac

### DIFF
--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -824,6 +824,7 @@ l2of_scsi()
     goto_dir $PWD "devspec"
 
     OF_PATH=`$CAT $PWD/devspec`
+    SYS_PATH=$PWD
     if [[ -z $OF_PATH ]]; then
         err $ERR_NO_OFPATH
     fi
@@ -942,6 +943,13 @@ l2of_scsi()
             fi
 	fi
     else
+
+        plug_id=$(ls -dv $SYS_PATH/*/host* 2>/dev/null | grep -n "/host$HOST$")
+        [ -z "$plug_id" ] && {
+                plug_id=$(ls -dv $SYS_PATH/host* 2>/dev/null | grep -n "/host$HOST$")
+        }
+        plug_id=$((${plug_id%%:*}-1))
+
         # make sure the "scsi" information is on the end of the path
         local scsi_name=${OF_PATH##/*/}
         scsi_name=${scsi_name%%@*}

--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -519,6 +519,13 @@ l2of_ide()
     if [[ -z $link ]]; then
         err $ERR_NO_SYSFS_DEVINFO
     fi
+
+    # partition number: N in sd*N
+    local devpart="${DEVICE##*[a-z]}"
+    if [[ $devpart = $DEVICE ]]; then
+        devpart='' # no partition number
+    fi
+
     cd $link
 
     # get the device number
@@ -584,6 +591,13 @@ l2of_vd()
     if [[ -z $OF_PATH ]]; then
         err $ERR_NO_OFPATH
     fi
+
+    # No partition specified.
+    if [[ -z $devpart ]]; then
+        return
+    fi
+
+    OF_PATH="${OF_PATH}:${devpart}"
 }
 
 #
@@ -786,6 +800,12 @@ l2of_scsi()
         err $ERR_NOT_CONFIG
     fi
 
+    # partition number: N in sd*N
+    local devpart="${DEVICE##*[a-z]}"
+    if [[ $devpart = $DEVICE ]]; then
+        devpart='' # no partition number
+    fi
+
     # follow the 'device' link
     local link=`get_link "device"`
     if [[ -z $link ]]; then
@@ -944,6 +964,13 @@ l2of_scsi()
              OF_PATH=$OF_PATH/sd@$ID,$LUN
        fi
     fi
+
+    # No partition specified.
+    if [[ -z $devpart ]]; then
+        return
+    fi
+
+    OF_PATH="${OF_PATH}:${devpart}"
 }
 
 #

--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -37,6 +37,8 @@ PSERIES_PLATFORM=$(dirname $0)/pseries_platform
 PLATFORM=$(sed /proc/cpuinfo -ne "s/^machine\t*: \(.*\)/\1/p")
 case $PLATFORM in
     EFIKA5K2\ *)	PLATFORM=efika ;;
+    PowerBook*)		PLATFORM=mac ;;
+    PowerMac*)		PLATFORM=mac ;;
 esac
 
 # Usage statemnet
@@ -554,7 +556,11 @@ l2of_ide()
         devno=0,0
     fi
 
-    OF_PATH=$OF_PATH/disk@$devno
+    if [ "$PLATFORM" = "mac" ] ; then
+        OF_PATH=$OF_PATH/@$devno
+    else
+        OF_PATH=$OF_PATH/disk@$devno
+    fi
 }
 
 #
@@ -953,8 +959,11 @@ l2of_scsi()
         # make sure the "scsi" information is on the end of the path
         local scsi_name=${OF_PATH##/*/}
         scsi_name=${scsi_name%%@*}
-        if [[ $scsi_name != "scsi" ]]; then
+        if [[ $scsi_name != "scsi" && "$PLATFORM" != "mac" ]]; then
             scsi_name="scsi@$BUS"
+            OF_PATH=$OF_PATH/$scsi_name
+        elif [[ $scsi_name != "scsi" && "$PLATFORM" = "mac" && $devtype != "ata" ]]; then
+            scsi_name="@$plug_id"
             OF_PATH=$OF_PATH/$scsi_name
         fi
 
@@ -969,7 +978,11 @@ l2of_scsi()
              diskno=`get_scsi_disk_no $device_dir`
              OF_PATH=$OF_PATH/disk\@$diskno
         else
-             OF_PATH=$OF_PATH/sd@$ID,$LUN
+             if [ "$PLATFORM" = "mac" ] ; then
+                 OF_PATH=$OF_PATH/@$ID
+             else
+                 OF_PATH=$OF_PATH/sd@$ID,$LUN
+             fi
        fi
     fi
 


### PR DESCRIPTION
This patch set contains fixes to make ```ofpathname``` work properly on Apple Power Mac.

I also sent this patch set to the mailing list, but neither the patches nor my long cover letter showed up on the list. So I'm just opening a PR here.