### PR TITLE
ofpathname and bootlist fixes

### DIFF
--- a/scripts/bootlist
+++ b/scripts/bootlist
@@ -169,11 +169,11 @@ get_logical_device_name()
     local devname=$1
     local logical_name
 
-    logical_name=`$OFPATHNAME -l $devname 2>/dev/null | tr -d '\000'`
+    logical_name=`$OFPATHNAME -l $devname 2>/dev/null`
     if [[ $? -ne 0 ]]; then
 	echo ""
     else
-	echo $logical_name
+	echo $logical_name | tr -d '\000'
     fi
 }
 

--- a/scripts/bootlist
+++ b/scripts/bootlist
@@ -211,7 +211,7 @@ show_bootlist()
 	if [[ $TRANSLATE_NAMES = "yes" ]]; then
 	    name=`get_logical_device_name $i`
 	    if [[ -z $name ]]; then
-	        echo "Could not translate $i to logical device name" 2>&1
+	        echo "Could not translate $i to logical device name" >&2
 	    else
 		case $name in
 		    eth*)   parse_eth_info $name $i ;;
@@ -230,7 +230,7 @@ show_bootlist()
 
 . $PSERIES_PLATFORM
 if [[ $platform != $PLATFORM_PSERIES_LPAR ]]; then
-    echo "bootlist: is not supported on the $platform_name platform" 2>&1
+    echo "bootlist: is not supported on the $platform_name platform" >&2
     exit 1
 fi
 

--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -349,7 +349,7 @@ is_pata_dev()
     local sysfs_dir
     local udev_path
     local udevinfo="/usr/bin/udevinfo"
-    local udevadm="/sbin/udevadm"
+    local udevadm="/usr/bin/udevadm"
 
     if [[ -a $udevadm ]]; then
         udev_path=`$udevadm info --query=path --name=$DEVNAME`


### PR DESCRIPTION
…are path

With commit 73839d6bab4d ("powerpc-utils: Suppress errors reading kernel files")
the return status of tr rather than ofpathname is tested.

Fixes: 73839d6bab4d ("powerpc-utils: Suppress errors reading kernel files")

Signed-off-by: Michal Suchanek <msuchanek@suse.de>