### PR TITLE
ofpathname: Remove the dependency on bc

### DIFF
--- a/powerpc-utils.spec.in
+++ b/powerpc-utils.spec.in
@@ -11,7 +11,6 @@ Source:		powerpc-utils-%{version}.tar.gz
 BuildRoot:	/tmp/%{name}-buildroot/
 Vendor:         IBM Corp.
 Requires:	/bin/bash, /bin/sh, /bin/sed, /usr/bin/perl, librtas >= 1.4.0, zlib
-Requires:	bc
 Requires:	coreutils
 Requires:	findutils
 Requires:	gawk

--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -142,13 +142,10 @@ get_hbtl()
 
     HOST=${hbtl%%:*}
     hbtl=${hbtl#*:}
-    BUS=${hbtl%%:*}
-    BUS=`echo "ibase=10;obase=16; $BUS" | bc | tr "[:upper:]" "[:lower:]"`
+    BUS=`printf '%x' "${hbtl%%:*}"`
     hbtl=${hbtl#*:}
-    ID=${hbtl%%:*}
-    ID=`echo "ibase=10;obase=16; $ID" | bc | tr "[:upper:]" "[:lower:]"`
-    LUN=${hbtl#*:}
-    LUN=`echo "ibase=10;obase=16; $LUN" | bc | tr "[:upper:]" "[:lower:]"`
+    ID=`printf '%x' "${hbtl%%:*}"`
+    LUN=`printf '%x' "${hbtl#*:}"`
 }
 
 #
@@ -172,13 +169,7 @@ get_scsi_disk_no()
     local vdiskno vdisk
     typeset -i vdiskno
     vdiskno=$((0x1000000 | $C | $D ))
-    vdisk=${vdiskno##-}
-
-    vdisk=`echo \`bc << END
-ibase=10
-obase=16
-$vdisk
-END\``
+    vdisk=`printf '%X' "${vdiskno#-}"`
 
     local extrazeroes="00000000"
     echo $vdisk$extrazeroes
@@ -208,13 +199,7 @@ get_vdisk_no()
     local vdiskno vdisk
     typeset -i vdiskno
     vdiskno=$((0x8000 | $B | $C | $D ))
-    vdisk=${vdiskno##-}
-
-    vdisk=`echo \`bc << END
-ibase=10
-obase=16
-$vdisk
-END\``
+    vdisk=`printf '%X' "${vdiskno#-}"`
 
     local extrazeroes="000000000000"
     echo $vdisk$extrazeroes
@@ -240,14 +225,8 @@ get_usb_vdisk_no()
 
         local vdiskno vdisk
         vdiskno=$((0x1000000 | $B | $LUN ))
-        vdisk=${vdiskno##-}
+        vdisk=`printf '%X' "${vdiskno#-}"`
 
-vdisk=$(bc << END
-ibase=10
-obase=16
-$vdisk
-END
-)
         local extrazeroes="00000000"
         echo $vdisk$extrazeroes
 }
@@ -724,9 +703,7 @@ scsilun_to_int()
     local lunstr=$1
     local A B C D L
 
-    L=${lunstr/00000000}
-    L=`echo $L | tr "[a-z]" "[A-Z]"`
-    L=`echo "ibase=16;obase=A; $L" | bc`
+    L=$(( 0x${lunstr/00000000} ))
 
     A=$(( ($L >> 8) & 0xff ))
     B=$(($L & 0xff))
@@ -740,9 +717,7 @@ scsilun_to_int()
 get_fc_scsilun()
 {
     local lun=$1
-    local L
-    L=`echo $lun | tr "[a-z]" "[A-Z]"`
-    L=`echo "ibase=16;obase=A; $L" | bc`
+    local L=$(( 0x$lun ))
 
     local fc_lun=`int_to_scsilun $L`
     echo "$fc_lun"
@@ -906,12 +881,9 @@ l2of_scsi()
                     OF_PATH=$(printf "%s,%s" $OF_PATH $LUNSTR)
                 fi
             else
-                B=`echo $BUS | tr "[a-z]" "[A-Z]"`
-                B=`echo "ibase=16;obase=A; $B" | bc`
-                T=`echo $ID | tr "[a-z]" "[A-Z]"`
-                T=`echo "ibase=16;obase=A; $T" | bc`
-                L=`echo $LUN | tr "[a-z]" "[A-Z]"`
-                L=`echo "ibase=16;obase=A; $L" | bc`
+                B=$(( 0x$BUS ))
+                T=$(( 0x$ID ))
+                L=$(( 0x$LUN ))
 
                 sas_id=$(( ($B << 16) | ($T << 8) | $L ))
 
@@ -1371,18 +1343,13 @@ of2l_sas()
         local device_dir=$PWD
 
         local B T L
-        B=`echo $BUS | tr "[a-z]" "[A-Z]"`
-        B=`echo "ibase=16;obase=A; $B" | bc`
-        T=`echo $ID | tr "[a-z]" "[A-Z]"`
-        T=`echo "ibase=16;obase=A; $T" | bc`
-        L=`echo $LUN | tr "[a-z]" "[A-Z]"`
-        L=`echo "ibase=16;obase=A; $L" | bc`
+        B=$(( 0x$BUS ))
+        T=$(( 0x$ID ))
+        L=$(( 0x$LUN ))
 
         if [[ $matchtype = "ipr32" ]]; then
             local sas_id=$((($B << 16) | ($T << 8) | $L))
-
-            sas_id=`echo "ibase=A;obase=16; $sas_id" | bc`
-            sas_id=`echo $sas_id | tr "[A-Z]" "[a-z]"`
+            sas_id=`printf '%x' "$sas_id"`
 
             if [[ $sas_id = $DEV_ID ]]; then
                 goto_dir $PWD "devspec"
@@ -1556,9 +1523,7 @@ of2l_fc()
 	local wwpn=`get_fc_wwpn "$device_path/fc_remote_ports*"`
 
         if [[ $wwpn = $OF_WWPN ]]; then
-                local L
-                L=`echo $LUN | tr "[a-z]" "[A-Z]"`
-                L=`echo "ibase=16;obase=A; $L" | bc`
+                local L=$(( 0x$LUN ))
 
                 if [[ $L = $lunint ]]; then
                         LOGICAL_DEVNAME="${dir##*/}"


### PR DESCRIPTION
The only use of `bc` is to convert between decimal and hexadecimal integers, but this functionality is supported by [POSIX shell arithmetic expansion](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_04) and a [POSIX-compatible `printf` program](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html).  Since this script uses `#!/bin/bash`, the `printf` utility is a bash builtin, so it won't even add a dependency on an external `printf` program (which is provided by the required coreutils package anyway).