### PR TITLE
drmgr: ignore timeout when DLPAR in progress

### DIFF
--- a/src/drmgr/common_pci.c
+++ b/src/drmgr/common_pci.c
@@ -1328,7 +1328,7 @@ pci_remove_device(struct dr_node *node)
 			sleep(1);
 		}
 	} while (rc == 0 &&
-		 (++wait_time < PCI_REMOVE_TIMEOUT_MAX && !drmgr_timed_out()));
+		 (++wait_time < PCI_REMOVE_TIMEOUT_MAX));
 
 	if (rc == 0) {
 		say(ERROR, "timeout while quiescing device at %s\n",
@@ -1393,9 +1393,6 @@ static int dlpar_io_kernel_op(const char *interface_file, const char *drc_name)
 		}
 
 		sleep(1);
-
-		if (drmgr_timed_out())
-			break;
 	} while (1);
 
 	return -1;

--- a/src/drmgr/drslot_chrp_cpu.c
+++ b/src/drmgr/drslot_chrp_cpu.c
@@ -239,9 +239,6 @@ static int add_cpus(struct dr_info *dr_info)
 
 	count = 0;
 	while (count < usr_drc_count) {
-		if (drmgr_timed_out())
-			break;
-
 		cpu = get_available_cpu(dr_info);
 		if (!cpu)
 			break;
@@ -293,9 +290,6 @@ static int remove_cpus(struct dr_info *dr_info)
 	struct dr_node *cpu;
 
 	while (count < usr_drc_count) {
-		if (drmgr_timed_out())
-			break;
-
 		if (cpu_count(dr_info) == 1) {
 			say(WARN, "Cannot remove the last CPU\n");
 			rc = -1;

--- a/src/drmgr/drslot_chrp_mem.c
+++ b/src/drmgr/drslot_chrp_mem.c
@@ -1148,9 +1148,6 @@ static int add_lmbs(struct lmb_list_head *lmb_list)
 
 	lmb_list->lmbs_modified = 0;
 	while (lmb_list->lmbs_modified < usr_drc_count) {
-		if (drmgr_timed_out())
-			break;
-
 		lmb = get_available_lmb(lmb_head);
 		if (lmb == NULL)
 			return -1;
@@ -1231,9 +1228,6 @@ static int remove_lmbs(struct lmb_list_head *lmb_list)
 	int rc;
 
 	while (lmb_list->lmbs_modified < usr_drc_count) {
-		if (drmgr_timed_out())
-			break;
-
 		lmb = get_available_lmb(lmb_head);
 		if (!lmb)
 			return -1;


### PR DESCRIPTION
Continue to honor the specified timeout when waiting for the lock
which serializes executions of drmgr, but do not abort an operation in
progress if the timeout is exceeded. There are several justifications
for this:

1. With contemporary kernels this is the de facto behavior with memory
   already, since the kernel does all the work in a single
   uninterruptible operation. This change makes the behavior for all
   types of resources consistent.

2. I'm unaware of any problem reports involving memory operations
   exceeding the timeout, which they assuredly do for larger
   quantities. However, I do have reports of the default timeout
   undesirably and surprisingly causing relatively modest CPU
   operations in progress to abort. From this I conclude that users
   generally aren't aware of the timeout until it gets in their way.

3. There is no reasonable way to "tune" the timeout value to the
   quantity of the resource being changed. The time it takes for a
   given operation depends not only on the specified quantity but also
   on kernel implementation details and other system activity.

4. Aborting an operation in progress exercises seldom-tested error
   paths in the code.

Signed-off-by: Nathan Lynch <nathanl@linux.ibm.com>