### PR TITLE
Update ppc64-cpu usage

### DIFF
--- a/src/ppc64_cpu.c
+++ b/src/ppc64_cpu.c
@@ -1195,7 +1195,8 @@ static void usage(void)
 "ppc64_cpu --subcores-per-core       # Get number of subcores per core\n"
 "ppc64_cpu --subcores-per-core=X     # Set subcores per core to X (1 or 4)\n"
 "ppc64_cpu --threads-per-core        # Get threads per core\n"
-"ppc64_cpu --info                    # Display system state information)\n");
+"ppc64_cpu --info                    # Display system state information\n"
+"ppc64_cpu --version                 # Display version of ppc64-cpu\n");
 }
 
 struct option longopts[] = {


### PR DESCRIPTION
'ppc64_cpu --help' doesn't list '--version' as an option. This patch
adds the option in the usage information of ppc64-cpu command.

Signed-off-by: Brahadambal Srinivasan <latha@linux.vnet.ibm.com>