### PR TITLE
hcn-init fixes

### DIFF
--- a/scripts/hcnmgr
+++ b/scripts/hcnmgr
@@ -168,7 +168,7 @@ search_dev() {
 	# Look at pci ethernet devices
 	for pci_dev in "$DT_PATH"/pci*; do
 		[ -d "$pci_dev" ] || continue
-		index=$(xxd -l 4 -p "$pci_dev"/ibm,my-drc-index)
+		index=$(hexdump -n 4 -e '/1 "%02x"' "$pci_dev"/ibm,my-drc-index)
 		if [[ $index != "$1" ]]; then
 			continue
 		fi
@@ -189,7 +189,7 @@ search_dev() {
 	hcnlog DEBUG "search vnic device with drc_index $1"
 	for dev in "$DT_PATH"/vdevice/vnic*; do
 		[ -d "$dev" ] || continue
-		index=$(xxd -l 4 -p "$dev"/ibm,my-drc-index)
+		index=$(hexdump -n 4 -e '/1 "%02x"' "$dev"/ibm,my-drc-index)
 		if [[ $index == "$1" ]]; then
 			hcnlog DEBUG "found matching drc_index $index in $dev"
 			if [ -e "$dev"/ibm,hcn-id ] && get_dev_hcn "$dev"; then
@@ -205,7 +205,7 @@ search_dev() {
 	hcnlog DEBUG "search ibmveth device with drc_index $1"
 	for dev in "$DT_PATH"/vdevice/l-lan*; do
 		[ -d "$dev" ] || continue
-		index=$(xxd -l 4 -p "$dev"/ibm,my-drc-index)
+		index=$(hexdump -n 4 -e '/1 "%02x"' "$dev"/ibm,my-drc-index)
 		if [[ $index == "$1" ]]; then
 			hcnlog DEBUG "found matching drc_index $index in $dev"
 			if [ -e "$dev"/ibm,hcn-id ] && get_dev_hcn "$dev"; then
@@ -233,7 +233,7 @@ get_dev_hcn() {
 	local dev=$1
 
 	hcnlog DEBUG "get_dev_hcn: enter $1"
-	HCNID=$(xxd -l 4 -p "$dev"/ibm,hcn-id)
+	HCNID=$(hexdump -n 4 -e '/1 "%02x"' "$dev"/ibm,hcn-id)
 	MODE=$(tr -d '\0' <"$dev"/ibm,hcn-mode)
 	PHYSLOC=$(tr -d '\0' <"$dev"/ibm,loc-code)
 	DEVPATH=$1

--- a/scripts/hcnmgr
+++ b/scripts/hcnmgr
@@ -284,7 +284,7 @@ do_config_vdevice() {
 
 	hcnlog DEBUG "Check if there is bond $BONDNAME with hcn id $HCNID"
 
-	if ! nmcli -f NAME con show --active | grep -q "$BONDNAME\s"; then
+	if ! nmcli -f NAME con show | grep -q "$BONDNAME\s"; then
 		hcnlog INFO "nmcli con add type bond con-name $BONDNAME ifname $BONDNAME"
 		nmcli con add type bond con-name "$BONDNAME" ifname "$BONDNAME"
 

--- a/scripts/hcnmgr
+++ b/scripts/hcnmgr
@@ -289,8 +289,8 @@ do_config_vdevice() {
 		nmcli con add type bond con-name "$BONDNAME" ifname "$BONDNAME"
 
 		#vnic and sr-iov only support fail_over_mac=2 mode
-		hcnlog INFO "nmcli con mod id $BONDNAME bond.options $BONDOPTIONS"
-		nmcli con mod id "$BONDNAME" bond.options "$BONDOPTIONS"
+		hcnlog INFO "nmcli con mod id $BONDNAME bond.options $BONDOPTIONS connection.autoconnect-slaves 1"
+		nmcli con mod id "$BONDNAME" bond.options "$BONDOPTIONS" connection.autoconnect-slaves 1
 		# When creating bond, by default the ipv4.method is auto, set to dhcp
 		# In the case of mutiple HNV this can case bond interface deactive and
 		# active again. In addtion HNV requires user to configure IP address manually.

--- a/systemd/hcn-init.service.in
+++ b/systemd/hcn-init.service.in
@@ -1,11 +1,12 @@
 [Unit]
 Description=hybrid virtual network scan and config
-After=network-online.target
-Wants=network-online.target
+After=NetworkManager.service
+Requisite=NetworkManager.service
+PartOf=NetworkManager.service
 
 [Service]
 Type=oneshot
 ExecStart=@sbindir@/hcnmgr -s
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=NetworkManager.service


### PR DESCRIPTION
hcn-init.service: Start together with NetworkManager.

hcn-init uses NetworkManager so it does not make sense to run it when
different connection manager is in use. Also when NetworkManager is in
use it should be started automatically.

hcnmgr: Use hexdump from util-linux rather than xxd from vim

xxd is part of vim which may not be installed in minimal environments or
on systems using other text editor. hexdump is part of util-linux which
is likely to be available.
