### PR TITLE
add includes/defines for musl libc support

### DIFF
--- a/src/common/cpu_info_helpers.c
+++ b/src/common/cpu_info_helpers.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <dirent.h>
+#include <limits.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include "cpu_info_helpers.h"

--- a/src/drmgr/common.c
+++ b/src/drmgr/common.c
@@ -28,7 +28,9 @@
 #include <signal.h>
 #include <errno.h>
 #include <dirent.h>
+#ifdef __GLIBC__
 #include <execinfo.h>
+#endif
 #include <ctype.h>
 #include <sys/wait.h>
 #include <endian.h>
@@ -853,6 +855,7 @@ sighandler(int signo)
 	say(ERROR, "Received signal %d, attempting to cleanup and exit\n",
 	    signo);
 
+#ifdef __GLIBC__
 	if (log_fd) {
 		void *callstack[128];
 		int sz;
@@ -860,6 +863,7 @@ sighandler(int signo)
 		sz = backtrace(callstack, 128);
 		backtrace_symbols_fd(callstack, sz, log_fd);
 	}
+#endif
 
 	dr_fini();
 	exit(-1);
@@ -925,8 +929,10 @@ sig_setup(void)
 	if (sigaction(SIGBUS, &sigact, NULL))
 		return -1;
 
+#ifdef __GLIBC__
 	/* dummy call to backtrace to get symbol loaded */
 	backtrace(callstack, 128);
+#endif
 	return 0;
 }
 

--- a/src/drmgr/dr.h
+++ b/src/drmgr/dr.h
@@ -26,6 +26,7 @@
 #include <nl_types.h>
 #include <unistd.h>
 #include <stdarg.h>
+#include <limits.h>
 #include "rtas_calls.h"
 #include "drpci.h"
 

--- a/src/rtas_dbg.c
+++ b/src/rtas_dbg.c
@@ -32,6 +32,7 @@
 #include <getopt.h>
 #include <dirent.h>
 #include <string.h>
+#include <endian.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 #include <linux/unistd.h>


### PR DESCRIPTION
- add some missing includes to get proper definitions for beXXtoh and
  PATH_MAX
- guard backtrace() from execinfo.h usage for it is glibc only

Signed-off-by: Fabian Groffen <grobian@gentoo.org>