### PR TITLE
Miscellaneous bootlist / ofpathname fixes

### DIFF
--- a/scripts/bootlist
+++ b/scripts/bootlist
@@ -448,7 +448,7 @@ fi
 # open firmware device paths.
 if [[ ${#LOGICAL_NAMES[*]} -ne 0 ]]; then
     ctr=0
-    while [[ $ctr -lt ${#LOGICAL_NAMES[*]} ]]; do
+    while [[ $ctr -lt ${#LOGICAL_NAMES[*]} ]] && [[ $ctr -lt 5 ]]; do
         OF_DEVPATH[$ctr]=`get_logical_device_name ${LOGICAL_NAMES[$ctr]}`
         if [[ -z ${OF_DEVPATH[$ctr]} ]]; then
 	    # See if this is an OF pathname

--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -1512,6 +1512,11 @@ of2l_vfc()
                 err $ERR_NO_LOGDEV
         fi
 
+        # Skip if this is not the correct FC port
+        if [[ $OF_PATH != $DEVPATH ]] ; then
+                continue;
+        fi
+
         local vdev=${OF_PATH%/*}
         local tmp=${OF_PATH//\/vdevice/}
         local vdevtype=${tmp%@*}
@@ -1548,6 +1553,8 @@ of2l_fc()
     fi
 
     lunint=`scsilun_to_int $OF_LUN`
+# Need to correlate the node_name in fc_host with the port-wwn in the device tree
+# to be sure we have the right port
 
     local dir
     for dir in `$FIND /sys/block -name 's[dr]*'`; do
@@ -1581,6 +1588,11 @@ of2l_fc()
         OF_PATH=`$CAT devspec`
         if [[ -z $OF_PATH ]]; then
                 err $ERR_NO_LOGDEV
+        fi
+
+        # Skip if this is not the correct FC port
+        if [[ $OF_PATH != $DEVPATH ]] ; then
+                continue;
         fi
 
 	local wwpn=`get_fc_wwpn "$device_path/fc_remote_ports*"`

--- a/scripts/ofpathname
+++ b/scripts/ofpathname
@@ -989,10 +989,6 @@ ofpathname_to_logical()
         print_aliases $OF_PATH
     fi
 
-    if [[ $DEVTYPE = "disk" && $DEVICE != ${DEVICE%:*} ]]; then
-        DEVTYPE=${DEVICE%:*}
-    fi
-
     if [[ $DEVTYPE = "disk" && $FC = "v-scsi" ]]; then
         DEVTYPE="v-scsi"
     fi
@@ -1047,6 +1043,13 @@ ofpathname_to_logical()
 	DEVICE=${DEVICE%,*}
     fi
 
+    # Remove any possible partition reference
+    PART=$(expr "$DEVICE" : '.*\(:[0-9]\)')
+    if [[ -n $PART ]] ; then
+        PART=${PART:1}
+        DEVICE=${DEVICE%:[0-9]}
+    fi
+
     case $DEVTYPE in
         sd* | scsi*   )  of2l_scsi ;;
         sas           )  of2l_sas ;;
@@ -1066,6 +1069,11 @@ ofpathname_to_logical()
 
     if [[ -z $LOGICAL_DEVNAME ]]; then
         err $ERR_NO_LOGDEV
+    fi
+
+    # Add any previously stripped partition reference
+    if [[ -n $PART ]] ; then
+        LOGICAL_DEVNAME=$LOGICAL_DEVNAME$PART
     fi
 
     # See if this device is the cdrom


### PR DESCRIPTION
In fixing a bootlist bug with multipath devices with > 5 paths, I discovered a couple ofpathname bugs in the OF to logical lookup path. This pull request contains three changes.

ofpathname: Fix OF to logical FC lookup for multipath
ofpathname: Fix OF to logical lookup with partitions
bootlist: Fix for multipath devices with > 5 paths