### PR TITLE
Fix checking HCNID array size at boot time

### DIFF
--- a/scripts/hcnmgr
+++ b/scripts/hcnmgr
@@ -605,7 +605,7 @@ scanhcn() {
 		done
 	fi
 
-	if [ ${HcnIds[@]} -eq 0 ]; then
+	if [ ${#HcnIds[@]} -eq 0 ]; then
 		hcnlog DEBUG "scanhcn: scan for hybrid virtual network finished"
 		return $E_SUCCESS
 	fi


### PR DESCRIPTION
In commit 0b59d4a372aa266caa75f3b6a253b8f5aeaf3802 it checks the HCNID array
empty to avoid cleanup non-HNV related network profiles after reboot.
hcnmgr scan run log shows checking the number of HCNID array elements has
not done properly.

Signed-off-by: Mingming Cao <mmc@linux.vnet.ibm.com>