### PR TITLE
ppc64_cpu: Add support to parse PAPR information for energy and frequency Power 10 onwards

### DIFF
--- a/src/ppc64_cpu.c
+++ b/src/ppc64_cpu.c
@@ -291,7 +291,7 @@ static int set_one_smt_state(int thread, int online_threads)
 
 static int set_smt_state(int smt_state)
 {
-	int i, j, rc;
+	int i, j, rc = 0;
 	int error = 0;
 
 	if (!sysattr_is_writeable("online")) {


### PR DESCRIPTION
Introduction of a new interface to parse energy and frequency information exported to "/sys/firmware/papr/energy_scale_info/" using the new H_CALL H_GET_ENERGY_SCALE_INFO.

Previously H_GET_EM_PARMS exported this information encoded within "power_mode_data", however this interface will be deprecated P10 onwards.

The new interface exports information as follows:
```
/sys/firmware/papr/energy_scale_info/
|-- <id>/
|-- desc
|-- value
|-- value_desc (if exists)
|-- <id>/
|-- desc
|-- value
|-- value_desc (if exists)
```

The kernel side of patches for enabling the interface have been posted here: https://patchwork.ozlabs.org/project/linuxppc-dev/list/?series=254841 

In addition to adding the ability to parse the new PAPR interface, the patchset also adds a commit to fix a trivial bug where the variable maybe uninitialized at the time of return.