### PR TITLE
lparstat: Fix reported online memory in legacy format

### DIFF
--- a/src/lparstat.c
+++ b/src/lparstat.c
@@ -834,7 +834,7 @@ void get_mem_total(struct sysentry *se, char *buf)
 	*nl = '\0';
 
 	if (o_legacy) {
-		sprintf(buf, "%d %s", atoi(mem) / 1024, "MB");
+		sprintf(buf, "%lld %s", atoll(mem) / 1024, "MB");
 	} else {
 		sprintf(buf, "%s %s", mem, unit);
 	}


### PR DESCRIPTION
On systems with more than 2TB of online memory, legacy mode
will calculate and report a negative value due to exceeding
the maximum value for a signed 32-bit integer:

$ lparstat -i | grep "Online Memory"
Online Memory : 3771084032 kB

$ lparstat -il | grep "Online Memory"
Online Memory : -511604 MB