### PR TITLE
hcnmgr: Fix hexdump format.

### DIFF
--- a/scripts/hcnmgr
+++ b/scripts/hcnmgr
@@ -155,6 +155,12 @@ hcnlog() {
 
 }
 
+# function xdump4:
+#	Print first 4 bytes of specified file in hexadecimal
+xdump4() {
+	hexdump -n 4 -ve '/1 "%02x"' "$1"
+}
+
 # function search_dev:
 #	Given DRX_INDEX, Search for device-tree, looking for migratable SR_IOV
 #	backend vnic or ibmveth device to configure hybrid network
@@ -168,7 +174,7 @@ search_dev() {
 	# Look at pci ethernet devices
 	for pci_dev in "$DT_PATH"/pci*; do
 		[ -d "$pci_dev" ] || continue
-		index=$(hexdump -n 4 -e '/1 "%02x"' "$pci_dev"/ibm,my-drc-index)
+		index=$(xdump4 "$pci_dev"/ibm,my-drc-index)
 		if [[ $index != "$1" ]]; then
 			continue
 		fi
@@ -189,7 +195,7 @@ search_dev() {
 	hcnlog DEBUG "search vnic device with drc_index $1"
 	for dev in "$DT_PATH"/vdevice/vnic*; do
 		[ -d "$dev" ] || continue
-		index=$(hexdump -n 4 -e '/1 "%02x"' "$dev"/ibm,my-drc-index)
+		index=$(xdump4 "$dev"/ibm,my-drc-index)
 		if [[ $index == "$1" ]]; then
 			hcnlog DEBUG "found matching drc_index $index in $dev"
 			if [ -e "$dev"/ibm,hcn-id ] && get_dev_hcn "$dev"; then
@@ -205,7 +211,7 @@ search_dev() {
 	hcnlog DEBUG "search ibmveth device with drc_index $1"
 	for dev in "$DT_PATH"/vdevice/l-lan*; do
 		[ -d "$dev" ] || continue
-		index=$(hexdump -n 4 -e '/1 "%02x"' "$dev"/ibm,my-drc-index)
+		index=$(xdump4 "$dev"/ibm,my-drc-index)
 		if [[ $index == "$1" ]]; then
 			hcnlog DEBUG "found matching drc_index $index in $dev"
 			if [ -e "$dev"/ibm,hcn-id ] && get_dev_hcn "$dev"; then
@@ -233,7 +239,7 @@ get_dev_hcn() {
 	local dev=$1
 
 	hcnlog DEBUG "get_dev_hcn: enter $1"
-	HCNID=$(hexdump -n 4 -e '/1 "%02x"' "$dev"/ibm,hcn-id)
+	HCNID=$(xdump4 "$dev"/ibm,hcn-id)
 	MODE=$(tr -d '\0' <"$dev"/ibm,hcn-mode)
 	PHYSLOC=$(tr -d '\0' <"$dev"/ibm,loc-code)
 	DEVPATH=$1


### PR DESCRIPTION
When the file contrains multiple consecutive same bytes the /1 format
shows them abbreviated with *. To avoid this problem use 4/1 format.

Also put the hexdump invocation into a function.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>