### PR TITLE
powerpc-utils/lparstat: Output of lparstat -E

### DIFF
--- a/src/lparstat.c
+++ b/src/lparstat.c
@@ -1126,9 +1126,9 @@ void print_scaled_output(int interval, int count)
 
 	print_system_configuration();
 
-	fprintf(stdout, "---Actual---                 -Normalized-\n");
-	fprintf(stdout, "%%busy  %%idle   Frequency     %%busy  %%idle\n");
-	fprintf(stdout, "------ ------  ------------- ------ ------\n");
+	fprintf(stdout, "---Actual---\t\t\t---Normalized---\n");
+	fprintf(stdout, "%%busy\t%%idle\tFrequency\t%%busy\t%%idle\n");
+
 	do {
 		if (interval) {
 			sleep(interval);
@@ -1144,7 +1144,7 @@ void print_scaled_output(int interval, int count)
 		nominal_freq = strtod(nominal_f, NULL);
 		effective_freq = strtod(effective_f, NULL);
 
-		fprintf(stdout, "%6s %6s %5.2fGHz[%3d%%] %6s %6s\n",
+		fprintf(stdout, "%s\t%s\t%.2f GHz [%d%%]\t%4s\t%4s\n",
 			purr, purr_idle,
 			effective_freq/1000,
 			(int)((effective_freq/nominal_freq * 100)+ 0.44 ),


### PR DESCRIPTION
The output of lparstat command is not well formatted. It looks like:

System Configuration
type=Dedicated mode=Capped smt=Off lcpu=6 mem=5679104 kB cpus=0 ent=6.00

---Actual---                 -Normalized-
%busy  %idle   Frequency     %busy  %idle
------ ------  ------------- ------ ------
  0.00   0.01  2.33GHz[ 80%]   0.00   0.01

There is no gap between the units GHz and value in frequency and also the
values are not aligned properly.After the changes the output of lparstat
is as below:

System Configuration
type=Dedicated mode=Capped smt=8 lcpu=4 mem=40770944 kB cpus=0 ent=4.00

---Actual---                    ---Normalized---
%busy   %idle   Frequency       %busy   %idle
0.00    0.03    2.29 GHz [100%] 0.00    0.03

Signed-off-by: Likhitha Korrapati <likhitha@linux.ibm.com>
Reported-by: Shirisha Ganta <shirisha.ganta1@ibm.com>
Reviewed-by: Brahadambal Srinivasan <latha@linux.vnet.ibm.com>