### PR TITLE
Fix bad report when non continuous CPU ids

### DIFF
--- a/src/common/cpu_info_helpers.c
+++ b/src/common/cpu_info_helpers.c
@@ -83,6 +83,20 @@ int __sysattr_is_writeable(char *attribute, int threads_in_system)
 	return test_sysattr(attribute, W_OK, threads_in_system);
 }
 
+int cpu_physical_id(int thread)
+{
+	char path[SYSFS_PATH_MAX];
+	int rc, physical_id;
+
+	sprintf(path, SYSFS_CPUDIR"/physical_id", thread);
+	rc = get_attribute(path, "%d", &physical_id);
+
+	/* This attribute does not exist in kernels without hotplug enabled */
+	if (rc && errno == ENOENT)
+		return -1;
+	return physical_id;
+}
+
 int cpu_online(int thread)
 {
 	char path[SYSFS_PATH_MAX];

--- a/src/common/cpu_info_helpers.h
+++ b/src/common/cpu_info_helpers.h
@@ -32,6 +32,7 @@
 
 extern int __sysattr_is_readable(char *attribute, int threads_in_system);
 extern int __sysattr_is_writeable(char *attribute, int threads_in_system);
+extern int cpu_physical_id(int thread);
 extern int cpu_online(int thread);
 extern int is_subcore_capable(void);
 extern int num_subcores(void);


### PR DESCRIPTION
This patch applies on top of next, here it is applied on top of the ppc64_cpu fix for the new SMT via SYS FS kernel API, but there is no dependencies.