### PR TITLE
nvram man page and --help output are not in sync

### DIFF
--- a/man/nvram.8
+++ b/man/nvram.8
@@ -67,6 +67,22 @@ be more verbose.
 \fB\--help
 print usage information including other low level options useful for
 debugging nvram.
+.TP
+\fB\--ascii \fIname
+print partition contents as ASCII text
+.TP
+\fB\--dump \fIname
+raw dump of partition (use --partitions to see names)
+.TP
+\fB\--nvram-size
+specify size of nvram data, must in multiples of 16 Bytes (for repair 
+operations)
+.TP
+\fB\--unzip \fIname
+decompress and print compressed data from partition
+.TP
+\fB\--zero | 0 \fR
+terminate config pairs with a NULL character
 .SH FILES
 /dev/nvram
 .SH AUTHOR


### PR DESCRIPTION
The nvram man page and the output from the --help option are not in sync and a few of the options are missing in man page.

The options that are missing are ascii, dump, nvram-size, zero. These options are added through the commit ids [1], [2].

This patch adds the above missing options to the nvram.

Signed-off-by: Likhitha Korrapati <likhitha@linux.ibm.com>
Reviewed-by: Sourabh Jain <sourabhjain@linux.ibm.com>
[1] https://github.com/ibm-power-utilities/powerpc-utils/commit/0e09f4e2898e7dea556479b018a7f4bf12108099
[2] https://github.com/ibm-power-utilities/powerpc-utils/commit/976dbe9bb7b01b135cac3e7bbd1dce0cdc88636a