### PR TITLE
nvram: error out if nvram-size is greater than the default value

### DIFF
--- a/src/nvram.c
+++ b/src/nvram.c
@@ -1507,6 +1507,10 @@ main (int argc, char *argv[])
 		break;
 	    case 's':	/* nvram-size */
 		nvram.nbytes = strtoul(optarg, &endp, 10);
+		if (nvram.nbytes > DEFAULT_NVRAM_SZ) {
+                   err_msg("nvram size shouldn't be greater than default nvram-size %d\n", DEFAULT_NVRAM_SZ );
+                   exit(1);
+		}
 		if (!*optarg || *endp) {
 		    err_msg("specify nvram-size as an integer\n");
 		    exit(1);


### PR DESCRIPTION
If the user specifies a nvram-size larger than the default value (DEFAULT_NVRAM_SZ = 1024 * 1024), it results in a segmentation fault.

Without the patch:

[root@xxx ~]# nvram --nvram-size 268435456
nvram: WARNING: expected 268435456 bytes, but only read 15360! Segmentation fault (core dumped)

The above issue is fixed by adding a check on nvram-size and error out if nvram-size is greater than the default value.

with the patch:

[root@xxx src]# ./nvram --nvram-size 268435456
./nvram: ERROR: nvram size must be less than the default nvram-size is 1048576


Reviewed-by: Sourabh Jain <sourabhjain@linux.ibm.com>